### PR TITLE
CI: monolith image-only deploy via GHCR

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,44 +1,139 @@
-name: Deploy to Server
+name: Monolith image-only deploy
 
 on:
   push:
     branches:
       - dev
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  deploy:
-
+  test:
+    name: Test monolith-mvp
     runs-on: ubuntu-latest
-
     steps:
-      # 1. Checkout the code
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Set up SSH
-      - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.8.0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          ssh-private-key: ${{ secrets.SSH_KEY }}
+          distribution: temurin
+          java-version: "21"
+          cache: maven
 
-      # 3. Copy project to the server
-      - name: Copy project to server
-        uses: appleboy/scp-action@v0.1.7
+      - name: Run tests
+        run: mvn -B -ntp -pl monolith-mvp -am test
+
+  build_and_push:
+    name: Build and push image to GHCR
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          source: .
-          target: /root/app
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          distribution: temurin
+          java-version: "21"
+          cache: maven
 
-      # 4. Build and deploy on the server
-      - name: Build and deploy on server
+      - name: Build application JAR
+        run: mvn -B -ntp -pl monolith-mvp -am package -DskipTests
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: monolith-mvp/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/courses-monolith:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/courses-monolith:dev-latest
+
+      - name: Export image metadata
+        id: meta
+        run: echo "image=ghcr.io/${{ github.repository_owner }}/courses-monolith:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Deploy image on server
+    runs-on: ubuntu-latest
+    needs: build_and_push
+    environment: production
+    steps:
+      - name: Deploy via SSH (image only, no source copy)
         uses: appleboy/ssh-action@v1.2.0
+        env:
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          APP_IMAGE: ${{ needs.build_and_push.outputs.image }}
+          APP_PORT: ${{ secrets.APP_PORT }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DEPLOY_PATH,GHCR_USERNAME,GHCR_TOKEN,APP_IMAGE,APP_PORT,POSTGRES_PORT,POSTGRES_DB,POSTGRES_USER,POSTGRES_PASSWORD
           script: |
-            cd /root/app
-            mvn clean install -U -Dmaven.test.skip=true
-            docker-compose up -d --build
+            set -e
+            cd "$DEPLOY_PATH"
+
+            if [ ! -f docker-compose.monolith.yml ]; then
+              echo "docker-compose.monolith.yml not found in $DEPLOY_PATH"
+              exit 1
+            fi
+
+            touch .env
+
+            upsert_var() {
+              KEY="$1"
+              VALUE="$2"
+              if grep -q "^${KEY}=" .env; then
+                sed -i "s|^${KEY}=.*|${KEY}=${VALUE}|" .env
+              else
+                echo "${KEY}=${VALUE}" >> .env
+              fi
+            }
+
+            upsert_var APP_IMAGE "$APP_IMAGE"
+            upsert_var APP_PORT "$APP_PORT"
+            upsert_var POSTGRES_PORT "$POSTGRES_PORT"
+            upsert_var POSTGRES_DB "$POSTGRES_DB"
+            upsert_var POSTGRES_USER "$POSTGRES_USER"
+            upsert_var POSTGRES_PASSWORD "$POSTGRES_PASSWORD"
+
+            PREV_IMAGE=$(docker inspect monolith-mvp --format='{{.Config.Image}}' 2>/dev/null || true)
+
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+            docker compose -f docker-compose.monolith.yml --env-file .env pull monolith-mvp
+            docker compose -f docker-compose.monolith.yml --env-file .env up -d --force-recreate monolith-mvp
+
+            sleep 10
+            if [ -z "$(docker ps --filter name=monolith-mvp --filter status=running --quiet)" ]; then
+              echo "Deployment failed: monolith-mvp container is not running"
+              if [ -n "$PREV_IMAGE" ]; then
+                upsert_var APP_IMAGE "$PREV_IMAGE"
+                docker compose -f docker-compose.monolith.yml --env-file .env up -d --force-recreate monolith-mvp
+              fi
+              exit 1
+            fi
+
+            docker image prune -af

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -77,14 +77,14 @@ jobs:
       - name: Deploy via SSH (image only, no source copy)
         uses: appleboy/ssh-action@v1.2.0
         env:
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          DEPLOY_PATH: '/backend'
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APP_IMAGE: ${{ needs.build_and_push.outputs.image }}
-          APP_PORT: ${{ secrets.APP_PORT }}
-          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
-          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          APP_PORT: 8080
+          POSTGRES_PORT: 5432
+          POSTGRES_DB: 'courses'
+          POSTGRES_USER: 'postgres'
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         with:
           host: ${{ secrets.SSH_HOST }}


### PR DESCRIPTION
## Что сделано
- Полностью обновлён `.github/workflows/maven-publish.yml`.
- Пайплайн теперь:
  1) гоняет тесты `monolith-mvp`;
  2) собирает и публикует Docker image в GHCR;
  3) деплоит на сервер через SSH в режиме **image-only** (без копирования исходников на сервер);
  4) обновляет `.env` и перезапускает `monolith-mvp` через `docker compose`;
  5) делает rollback на предыдущий image, если контейнер не поднялся.

## Ключевые изменения
- Убрана сборка на удалённом сервере (`mvn`/`docker-compose --build`).
- Добавлены этапы `test`, `build_and_push`, `deploy`.
- Используются секреты:
  - `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`
  - `DEPLOY_PATH`
  - `GHCR_USERNAME`, `GHCR_TOKEN`
  - `APP_PORT`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`

## Важно
- Коммит содержит только workflow-файл (`.github/workflows/maven-publish.yml`).