### PR TITLE
ci: fix GHCR image tags to lowercase namespace

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -61,12 +61,12 @@ jobs:
           file: monolith-mvp/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/courses-monolith:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/courses-monolith:dev-latest
+            ghcr.io/justblood/courses-monolith:${{ github.sha }}
+            ghcr.io/justblood/courses-monolith:dev-latest
 
       - name: Export image metadata
         id: meta
-        run: echo "image=ghcr.io/${{ github.repository_owner }}/courses-monolith:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        run: echo "image=ghcr.io/justblood/courses-monolith:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Deploy image on server


### PR DESCRIPTION
## Что исправлено
- В workflow `.github/workflows/maven-publish.yml` исправлены теги образа на lowercase namespace:
  - `ghcr.io/justblood/courses-monolith:${{ github.sha }}`
  - `ghcr.io/justblood/courses-monolith:dev-latest`
- Исправлен `Export image metadata` на тот же lowercase image reference.

## Причина
Пайплайн падал на шаге `Build and push Docker image` с ошибкой:
`repository name must be lowercase`
из-за использования `${{ github.repository_owner }}` (для `JustBlood` это mixed-case).

## Ожидаемый результат
`docker/build-push-action` сможет собрать и запушить образ в GHCR без ошибки валидации тега.